### PR TITLE
signupページにアクセスできなかったので、middlewareのmatherを変更

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -27,7 +27,7 @@ export default withAuth(
 );
 
 export const config = {
-    // matcher: ["/((?!signup|api).*)"],
+    matcher: ["/((?!signup|api|signin).*)"],
     // matcher: ["/", "/report", "/partner", "/setting", "/signin"],
-    matcher: ["/(.*)"],
+    // matcher: ["/(.*)"],
 };


### PR DESCRIPTION
signupページに遷移できなかったため、レンダリング時に行われる認証確認をsigninとsingupとapiを除くようにしました。