### PR TITLE
signinとsingupページにアクセスした時にローディングが終わらないので、解消

### DIFF
--- a/src/providers/SessionProvider.tsx
+++ b/src/providers/SessionProvider.tsx
@@ -20,10 +20,13 @@ export const CustomSessionProvider = ({ children }: { children: React.ReactNode 
         }
     }, [session]);
 
+    // console.log(pathName);
+
+    if (pathName === "/signin" || pathName === "/signup") {
+        return children; // ローディングを表示しない
+    }
+
     if (status === "loading" || user === null) {
-        if (pathName === "/signin" || pathName === "/signup") {
-            return children; // ローディングを表示しない
-        }
         return <Loading />;
     }
 


### PR DESCRIPTION
signinとsignpupでローディングしたまま画面が表示しなくなったため、SessionProviderで現在のパスがsigninとsignpupの時だけローディングしないように変更